### PR TITLE
added loading spinners and a shimmer for load more and userdata

### DIFF
--- a/components/loadingSpinner.tsx
+++ b/components/loadingSpinner.tsx
@@ -1,0 +1,9 @@
+import { Icon, IconType } from '@smartive-education/thierry-simon-mumble'
+
+export const LoadingSpinner = () => {
+  return (
+    <div className="animate-spin text-violet-600 mt-4">
+      <Icon type={IconType.mumble} size={56} />
+    </div>
+  )
+}

--- a/components/loadingUserShimmer.tsx
+++ b/components/loadingUserShimmer.tsx
@@ -1,0 +1,10 @@
+export const LoadingUserShimmer = () => {
+  return (
+    <div className="">
+      <div className="flex flex-col gap-2 animate-pulse">
+        <div className="h-7 w-1/3 bg-violet-300"></div>
+        <div className="h-5 w-1/2 bg-violet-300"></div>
+      </div>
+    </div>
+  )
+}

--- a/components/mumbelCard.tsx
+++ b/components/mumbelCard.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import { MumbleType } from '../types/Mumble'
 import { InteractionButtons } from './interactionButtons'
 import { useSession } from 'next-auth/react'
+import { LoadingUserShimmer } from './loadingUserShimmer'
 
 type Props = {
   mumble: MumbleType
@@ -21,19 +22,29 @@ export const MumbleCard = ({ mumble }: Props) => {
         roundedBorders={isReply ? false : true}
         profileImageUrl={mumble.user?.avatarUrl}
       >
-        {mumble.user && isLoggedIn && (
-          <Link href={`/profile/${mumble.user?.id}`}>
-            <div className="mb-m">
-              <User
-                type={isReply ? SizeType.SM : SizeType.BASE}
-                userName={mumble.user?.userName}
-                fullName={`${mumble.user?.firstName} ${mumble.user?.lastName}`}
-                userImageSrc={mumble.user?.avatarUrl}
-                datePosted={mumble.createdTimestamp}
-              />
-            </div>
-          </Link>
-        )}
+        {
+          // If session is null - the user is not logged in but initially all sessions are undefined but can also become sessions
+          session !== null && (
+            <Link href={`/profile/${mumble.user?.id}`}>
+              <div className="mb-m">
+                {
+                  // if session is undefined, it is not yet clear it user is logged in or not so show loading spinner - if not logged in the session becomes null
+                  !session ? (
+                    <LoadingUserShimmer />
+                  ) : (
+                    <User
+                      type={isReply ? SizeType.SM : SizeType.BASE}
+                      userName={mumble.user?.userName}
+                      fullName={`${mumble.user?.firstName} ${mumble.user?.lastName}`}
+                      userImageSrc={mumble.user?.avatarUrl}
+                      datePosted={mumble.createdTimestamp}
+                    />
+                  )
+                }
+              </div>
+            </Link>
+          )
+        }
         <Link href={`/mumble/${mumble.id}`}>
           <p>{mumble.text}</p>
           {mumble.mediaUrl && (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,14 +14,16 @@ import { getToken } from 'next-auth/jwt'
 import { getMumblesFromData, getHighestCount } from '../utils/helperFunctions'
 import { useSession } from 'next-auth/react'
 import { fetchMumblesWithUser } from '../services/queries'
+import { LoadingSpinner } from '../components/loadingSpinner'
+import { MumbleType } from '../types/Mumble'
 
-export default function PageHome({ fallback }: { fallback: unknown }) {
+export default function PageHome({ fallback }: { fallback: MumbleType[] }) {
   const { data: session } = useSession()
 
-  const { data, size, setSize, isValidating, mutate } = useMumblesWithUser(
-    10,
-    fallback
-  )
+  const { data, size, setSize, isValidating, mutate, isLoading } =
+    useMumblesWithUser(10, fallback)
+
+  console.log(data, fallback, isLoading, isValidating)
 
   return (
     <>
@@ -47,13 +49,17 @@ export default function PageHome({ fallback }: { fallback: unknown }) {
         <Cards posts={getMumblesFromData(data)} />
         <div className="flex justify-center align-center py-m">
           <div>
-            <Button
-              size={ButtonSize.large}
-              color={ButtonColor.violet}
-              onClick={() => setSize(size + 1)}
-            >
-              {isValidating ? 'Loading...' : 'Mehr laden!'}
-            </Button>
+            {isValidating ? (
+              <LoadingSpinner />
+            ) : (
+              <Button
+                size={ButtonSize.large}
+                color={ButtonColor.violet}
+                onClick={() => setSize(size + 1)}
+              >
+                Mehr laden!
+              </Button>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Ich habe einen Loading Spinner beim Load More und einen Shimmer für die Userdaten eingebaut. Kannst du mal schauen, ob das vor allem bei den Userdaten so ok ist? 

Auf der Index Seite werden die User nun auch kurz mit dem Shimmer angezeigt, da die Session geprüft wird. Hast du eine Idee, wie man das noch verhindern könnte?