### PR TITLE
changes in loading spinners

### DIFF
--- a/components/mumbleCard.tsx
+++ b/components/mumbleCard.tsx
@@ -14,6 +14,7 @@ export const MumbleCard = ({ mumble }: Props) => {
   const isReply = mumble.type === 'reply'
   const { data: session } = useSession()
   const isLoggedIn = session
+  console.log('session:', session, 'user:', mumble?.user?.id)
 
   return (
     <div className={!isReply ? 'mb-s' : 'mb-1'}>
@@ -29,7 +30,7 @@ export const MumbleCard = ({ mumble }: Props) => {
               <div className="mb-m">
                 {
                   // if session is undefined, it is not yet clear it user is logged in or not so show loading spinner - if not logged in the session becomes null
-                  !session ? (
+                  !session && mumble?.user?.id === undefined ? (
                     <LoadingUserShimmer />
                   ) : (
                     <User

--- a/components/mumbleCard.tsx
+++ b/components/mumbleCard.tsx
@@ -14,7 +14,6 @@ export const MumbleCard = ({ mumble }: Props) => {
   const isReply = mumble.type === 'reply'
   const { data: session } = useSession()
   const isLoggedIn = session
-  console.log('session:', session, 'user:', mumble?.user?.id)
 
   return (
     <div className={!isReply ? 'mb-s' : 'mb-1'}>
@@ -30,7 +29,7 @@ export const MumbleCard = ({ mumble }: Props) => {
               <div className="mb-m">
                 {
                   // if session is undefined, it is not yet clear it user is logged in or not so show loading spinner - if not logged in the session becomes null
-                  !session && mumble?.user?.id === undefined ? (
+                  !session || mumble?.user?.id === undefined ? (
                     <LoadingUserShimmer />
                   ) : (
                     <User

--- a/components/writePost.tsx
+++ b/components/writePost.tsx
@@ -19,6 +19,8 @@ import { useRouter } from 'next/router'
 import { FC, useEffect, useReducer, useState } from 'react'
 import { postMumble, postReply } from '../services/mutations'
 import { MumbleType } from '../types/Mumble'
+import { LoadingSpinner } from './loadingSpinner'
+import { LoadingUserShimmer } from './loadingUserShimmer'
 
 const reducer = function (state, action) {
   switch (action.type) {
@@ -172,12 +174,16 @@ export const WritePost: FC<WriteMumbleProps> = ({
       >
         <div className="mb-s">
           {isReply ? (
-            <User
-              type={SizeType.SM}
-              userName={session?.data?.user.username}
-              fullName={`${session?.data?.user.firstname} ${session?.data?.user.lastname}`}
-              userImageSrc={session?.data?.user.avatarUrl}
-            />
+            !session.data?.user ? (
+              <LoadingUserShimmer />
+            ) : (
+              <User
+                type={SizeType.SM}
+                userName={session?.data?.user.username}
+                fullName={`${session?.data?.user.firstname} ${session?.data?.user.lastname}`}
+                userImageSrc={session?.data?.user.avatarUrl}
+              />
+            )
           ) : (
             <Header type={HeaderType.h4} style={HeaderType.h4}>
               Hey, was läuft?

--- a/hooks/useMumblesWithUser.ts
+++ b/hooks/useMumblesWithUser.ts
@@ -35,5 +35,14 @@ export const useMumblesWithUser = (
       refreshInterval: 60000,
       parallel: true
     })
-  return { data, size, setSize, isValidating, mutate, isLoading }
+  return session
+    ? { data, size, setSize, isValidating, mutate, isLoading }
+    : {
+        data: [fallback],
+        size: 1,
+        isValidating: false,
+        isLoading: false,
+        setSize,
+        mutate
+      }
 }

--- a/hooks/useSingleMumbleWithUser.ts
+++ b/hooks/useSingleMumbleWithUser.ts
@@ -26,5 +26,13 @@ export const useSingleMumblesWithUser = (
       parallel: true
     }
   )
-  return { data, isLoading, isValidating, error, mutate }
+  return session
+    ? { data, isLoading, isValidating, error, mutate }
+    : {
+        data: fallback,
+        isLoading: false,
+        isValidating: false,
+        error: null,
+        mutate
+      }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -39,17 +39,15 @@ export default function PageHome({ fallback }: { fallback: MumbleType[] }) {
             repellat dicta.
           </Header>
         </div>
-        {session && (
-          <WritePost
-            data={getMumblesFromData(data)}
-            mutateFn={mutate}
-            count={getHighestCount(data)}
-          />
-        )}
+        <WritePost
+          data={getMumblesFromData(data)}
+          mutateFn={mutate}
+          count={getHighestCount(data)}
+        />
         <Cards posts={getMumblesFromData(data)} />
         <div className="flex justify-center align-center py-m">
           <div>
-            {isValidating ? (
+            {isLoading ? (
               <LoadingSpinner />
             ) : (
               <Button


### PR DESCRIPTION
Ich habe einige Änderungen gemacht und das Loading-Spinner verhalten zu verbessern, das ganze ist aber auch etwas unübersichtlicher und komplizierter geworden: 

- Hooks, welche eine Session brauchen so geändert, dass wenn keine Session da ist immer noch die Fallback-Daten ausgegeben werden. Sonst gab es immer einen kurzen Moment wo die Session undefined war und dann die Serverdaten neu geftched wurden, der Fallback aber nicht gezogen hat. Irgendwie denke ich sollte das SWR selber machen, ich habe das nun aber manuell implementiert. 
-  LoadingSpinner neben der Session auch von den vorhandenen Userdaten abhängig gemacht.
- In der Write-Komponenten beim User ebenfalls den Shimmer-Spinner eingebaut, wenn der User noch undefined ist. 